### PR TITLE
feat: implement a function to retrieve subtitles based on current playback time

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -1,14 +1,29 @@
 <script setup lang="ts">
+import { PlayerService } from './services/player/player.service'
 import { SubtitleService } from './services/subtitles/subtitle.service'
-import { LANGUAGES, PLATFORM } from './services/subtitles/types'
-import { onMounted } from 'vue'
+import { LANGUAGES } from './services/subtitles/types'
+import { PLATFORM } from './services/types'
+import { onMounted, ref } from 'vue'
+
+const currentSubtitle = ref('')
 
 onMounted(async () => {
+  const playerService = new PlayerService(PLATFORM.YOUTUBE)
   const subtitleService = new SubtitleService(PLATFORM.YOUTUBE)
-  console.log('subtitle service: ', await subtitleService.fetchSubtitles(LANGUAGES.EN))
+  const subtitles = await subtitleService.fetchSubtitles(LANGUAGES.EN)
+
+  setInterval(() => {
+    const currentTime = playerService.currentTime()
+    currentSubtitle.value = subtitleService.getCurrentSubtitle(
+      subtitles,
+      currentTime
+    )
+  }, 100)
 })
 </script>
 
 <template>
-  <div>Hello World</div>
+  <div style="font-size: 30px; background-color: red; text-align: center">
+    {{ currentSubtitle }}
+  </div>
 </template>

--- a/src/app/services/subtitles/platforms/subtitle-platform.interface.ts
+++ b/src/app/services/subtitles/platforms/subtitle-platform.interface.ts
@@ -1,8 +1,9 @@
-import { PLATFORM } from "@/app/services/types";
-import { LANGUAGES, Subtitle } from "@/app/services/subtitles/types";
+import { PLATFORM } from '@/app/services/types'
+import { LANGUAGES, Subtitle } from '@/app/services/subtitles/types'
 
 export interface SubtitlePlatformInterface {
   name: PLATFORM
 
   fetchSubtitles(lang: LANGUAGES): Promise<Subtitle[]>
+  getCurrentSubtitle(subtitles: Subtitle[], currentTime: number): string
 }

--- a/src/app/services/subtitles/platforms/youtube.ts
+++ b/src/app/services/subtitles/platforms/youtube.ts
@@ -50,6 +50,14 @@ export class YoutubeSubtitlePlatform implements SubtitlePlatformInterface {
 
     return await this.retrieveSubtitle(bestCaption)
   }
+
+  getCurrentSubtitle(subtitles: Subtitle[], currentTime: number): string {
+    const activeSubtitles = subtitles
+      .filter((sub) => currentTime >= sub.begin && currentTime <= sub.end)
+      .map((sub) => sub.text)
+
+    return activeSubtitles.at(-1) ?? ''
+  }
 }
 
 type YoutubeContent = {

--- a/src/app/services/subtitles/subtitle.interface.ts
+++ b/src/app/services/subtitles/subtitle.interface.ts
@@ -5,4 +5,5 @@ export interface SubtitleInterface {
   platform: SubtitlePlatformInterface
 
   fetchSubtitles(lang: LANGUAGES): Promise<Subtitle[]>
+  getCurrentSubtitle(subtitles: Subtitle[], currentTime: number): string
 }

--- a/src/app/services/subtitles/subtitle.service.ts
+++ b/src/app/services/subtitles/subtitle.service.ts
@@ -9,13 +9,17 @@ const platforms = {
 }
 
 export class SubtitleService implements SubtitleInterface {
-  platform: SubtitlePlatformInterface 
+  platform: SubtitlePlatformInterface
 
   constructor(platform: PLATFORM) {
-    this.platform = new platforms[platform]
+    this.platform = new platforms[platform]()
   }
 
   async fetchSubtitles(lang: LANGUAGES): Promise<Subtitle[]> {
     return this.platform.fetchSubtitles(lang)
+  }
+
+  getCurrentSubtitle(subtitles: Subtitle[], currentTime: number): string {
+    return this.platform.getCurrentSubtitle(subtitles, currentTime)
   }
 }


### PR DESCRIPTION
This PR adds the `getCurrentSubtitles` function that returns the appropriate subtitle text for the current playback position. The function takes the current time as input and returns the corresponding subtitle entry that should be displayed at that moment.

https://github.com/user-attachments/assets/076a0fd8-e7a1-402e-8139-530a023f628d

